### PR TITLE
Use setup from distutils when setuptools is not available

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,17 @@
 #!/usr/bin/env python
 # vim:fileencoding=utf-8:noet
 
-from setuptools import setup
+# While I generally consider it an antipattern to try and support both
+# setuptools and distutils with a single setup.py, in this specific instance
+# where certifi is a dependency of setuptools, it can create a circular
+# dependency when projects attempt to unbundle stuff from setuptools and pip.
+# Though we don't really support that, it makes things easier if we do this and
+# should hopefully cause less issues for end users.
+
+try:
+    from setuptools import setup
+except ImportError:
+    from distutils.core import setup
 
 from certifi import __version__
 


### PR DESCRIPTION
`setuptools` in gentoo depends on `certifi` (`certifi-shim`). So it is possible that `setuptools` is not installed and `certifi` is trying to install. You can reproduce this issue by cross compiling `setuptools`.

I've found workaround for this issue in original [certifi](https://github.com/certifi/python-certifi/blob/master/setup.py#L8-L17). Please use it.